### PR TITLE
Modificar consulta soporte pago mensual

### DIFF
--- a/helpers/contratistas.go
+++ b/helpers/contratistas.go
@@ -340,7 +340,7 @@ func TraerEnlacesDocumentosAsociadosPagoMensual(pago_mensual_id string) (documen
 
 	var respuesta_peticion map[string]interface{}
 
-	if response, err := getJsonTest(beego.AppConfig.String("UrlCrudCumplidos")+"/soporte_pago_mensual/?limit=-1&query=PagoMensualId.Id:"+pago_mensual_id, &respuesta_peticion); (err == nil) && (response == 200) {
+	if response, err := getJsonTest(beego.AppConfig.String("UrlCrudCumplidos")+"/soporte_pago_mensual/?limit=-1&query=PagoMensualId.Id:"+pago_mensual_id+",activo:true", &respuesta_peticion); (err == nil) && (response == 200) {
 		LimpiezaRespuestaRefactor(respuesta_peticion, &soportes_pagos_mensuales)
 		if len(soportes_pagos_mensuales) != 0 {
 			var ids_documentos []string


### PR DESCRIPTION
Se agrega filtro para traer sólo los documentos activos en la consulta en contrastistas.go. Esto hace parte de las modificaciones necesarias para implementar lo requerido en el issue https://github.com/udistrital/core_documentacion/issues/169